### PR TITLE
[WIP] Use node-tar instead of exec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+npm-debug.log
+tmp/

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,6 @@
+{
+    "node": true,
+    "mocha": true,
+    "indent": 2
+}
+

--- a/index.js
+++ b/index.js
@@ -1,11 +1,14 @@
 var RSVP = require('rsvp');
 var quickTemp = require('quick-temp');
-var exec = RSVP.denodeify(require('child_process').exec);
+var fs = require('fs');
+var fstream = require('fstream');
+var tar = require('tar');
+var zlib = require('zlib');
 
-TarGzip = function TarGzip(inputTree, name){
+var TarGzip = function TarGzip(inputTree, name){
   this.inputTree = inputTree;
   this.name = name || 'archive';
-}
+};
 
 TarGzip.prototype = {
   read: function(readTree){
@@ -15,9 +18,20 @@ TarGzip.prototype = {
     var tarName = [destDir, '/', outName, '.tar.gz'].join('');
 
     return readTree(this.inputTree).then(function (srcDir){
-      var args = ['tar', 'chz', '-C', srcDir, '-f', tarName, '.'].join(' ');
-      return exec(args).then(function(){
-        return destDir;
+      return new RSVP.Promise(function (resolve, reject) {
+        var reader = fstream.Reader({path: srcDir, follow: true});
+        var writer = fs.createWriteStream(tarName);
+        var packer = tar.Pack();
+        var gz = zlib.createGzip();
+
+        reader.on('error', reject);
+        gz.on('error', reject);
+        writer.on('error', reject);
+        writer.on('finish', function (){
+          resolve(destDir);
+        });
+
+        reader.pipe(packer).pipe(gz).pipe(writer);
       });
     });
   },

--- a/package.json
+++ b/package.json
@@ -12,13 +12,16 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "fstream": "^1.0.4",
     "quick-temp": "^0.1.2",
-    "rsvp": "^3.0.14"
+    "rsvp": "^3.0.14",
+    "tar": "^1.0.3"
   },
   "devDependencies": {
     "broccoli": "^0.13.3",
     "expect.js": "^0.3.1",
     "mocha": "^2.0.1",
-    "mocha-jshint": "0.0.9"
+    "mocha-jshint": "0.0.9",
+    "walk-sync": "^0.1.3"
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -34,7 +34,7 @@ describe('broccoli-targz', function(){
       });
   });
 
-  it('the tar contains the files from input the tree', function(done){
+  it('the tar contains the files and structure of the input tree', function(done){
     var inputPath = path.join(fixturePath);
     var tree = new Tar(inputPath);
 
@@ -49,10 +49,12 @@ describe('broccoli-targz', function(){
         fs.createReadStream(file).pipe(zlib.createGunzip()).pipe(parser);
 
         parser.on('entry', function (e){
-          tarEntries.push(e.path.split('/').slice(1).join('/'));
+          tarEntries.push(e.path);
         });
 
         parser.on('end', function (){
+          expect(tarEntries.length).to.equal(srcEntries.length);
+
           srcEntries.forEach(function (src){
             expect(tarEntries.indexOf(src)).to.be.above(-1);
           });

--- a/tests/index.js
+++ b/tests/index.js
@@ -2,11 +2,13 @@
 
 var path = require('path');
 var expect = require('expect.js');
-var walkSync = require('walk-sync');
 var broccoli = require('broccoli');
 var fs = require('fs');
+var zlib = require('zlib');
+var walkSync = require('walk-sync');
+var tarPackage = require('tar');
 
-// require('mocha-jshint')();
+require('mocha-jshint')();
 
 var Tar = require('..');
 
@@ -30,10 +32,35 @@ describe('broccoli-targz', function(){
         var outputPath = results.directory;
         expect(fs.existsSync(outputPath + '/archive.tar.gz'));
       });
-
   });
 
-  it('the tar contains the file from input the input tree');
+  it('the tar contains the files from input the tree', function(done){
+    var inputPath = path.join(fixturePath);
+    var tree = new Tar(inputPath);
+
+    builder = new broccoli.Builder(tree);
+    builder.build()
+      .then(function(results){
+        var file = results.directory + '/archive.tar.gz';
+        var parser = tarPackage.Parse();
+        var srcEntries = walkSync(inputPath);
+        var tarEntries = [];
+
+        fs.createReadStream(file).pipe(zlib.createGunzip()).pipe(parser);
+
+        parser.on('entry', function (e){
+          tarEntries.push(e.path.split('/').slice(1).join('/'));
+        });
+
+        parser.on('end', function (){
+          srcEntries.forEach(function (src){
+            expect(tarEntries.indexOf(src)).to.be.above(-1);
+          });
+
+          done();
+        });
+      }).catch(done);
+  });
 
   it('emits an <name>.gz file if options.name is set', function(){
     var inputPath = path.join(fixturePath);
@@ -45,5 +72,5 @@ describe('broccoli-targz', function(){
         var outputPath = results.directory;
         expect(fs.existsSync(outputPath + '/name.tar.gz'));
       });
-  })
+  });
 });


### PR DESCRIPTION
Closes #2
- Swap out cp.exec to system tar for node-tar module.
- Add body of test that checks content of tar file.
