### PR TITLE
Support non-constructor pattern.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,9 @@ var quickTemp = require('quick-temp');
 var exec = RSVP.denodeify(require('child_process').exec);
 
 TarGzip = function TarGzip(inputTree, name){
+  if (!(this instanceof TarGzip)) {
+    return new TarGzip(inputTree, name);
+  }
   this.inputTree = inputTree;
   this.name = name || 'archive';
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -45,5 +45,11 @@ describe('broccoli-targz', function(){
         var outputPath = results.directory;
         expect(fs.existsSync(outputPath + '/name.tar.gz'));
       });
-  })
+  });
+  
+  it('supports non-constructor pattern', function () {
+    var inputPath = path.join(fixturePath);
+    var tree = Tar(inputPath);
+    expect(tree).to.be.a(Tar);
+  });
 });


### PR DESCRIPTION
In the broccoli ecosystem it's common to do:

    var foo = require("foo");
    var tree = foo("src");

i.e. not needing to do `var tree = new foo("src");`

This change adds support for that.